### PR TITLE
Handle osx specific `ln` option name

### DIFF
--- a/bin/pyenv-link-version
+++ b/bin/pyenv-link-version
@@ -134,6 +134,7 @@ if [ -z "$dry" ]; then
     # Handle OS types
     case "$(uname -s)" in
         Darwin*)
+            # long form flags aren't supported
             ln -s "$venv_dir" "$pyenv_prefix_path";;
         *)
             ln --symbolic "$venv_dir" "$pyenv_prefix_path";;

--- a/bin/pyenv-link-version
+++ b/bin/pyenv-link-version
@@ -131,7 +131,13 @@ pyenv_prefix_path="$PYENV_ROOT/versions/$venv_name"
 
 # link to pyenv version directory
 if [ -z "$dry" ]; then
-    ln --symbolic "$venv_dir" "$pyenv_prefix_path"
+    # Handle OS types
+    case "$(uname -s)" in
+        Darwin*)
+            ln -s "$venv_dir" "$pyenv_prefix_path";;
+        *)
+            ln --symbolic "$venv_dir" "$pyenv_prefix_path";;
+    esac
 fi
 
 # output


### PR DESCRIPTION
On OSX `ln` does not have `--symbolic` only `-s`.

OS type checking could be extended based on this:
https://stackoverflow.com/questions/3466166/how-to-check-if-running-in-cygwin-mac-or-linux